### PR TITLE
Prepare for release v2022.12.28

### DIFF
--- a/catalog/raw/vaultserver/vaultserver-0.11.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-0.11.5.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:0.11.5
   version: 0.11.5

--- a/catalog/raw/vaultserver/vaultserver-1.10.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.10.3.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.10.3
   version: 1.10.3

--- a/catalog/raw/vaultserver/vaultserver-1.11.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.11.5.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.11.5
   version: 1.11.5

--- a/catalog/raw/vaultserver/vaultserver-1.12.1.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.12.1.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.12.1
   version: 1.12.1

--- a/catalog/raw/vaultserver/vaultserver-1.2.0.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.0.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.2.0
   version: 1.2.0

--- a/catalog/raw/vaultserver/vaultserver-1.2.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.2.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.2.2
   version: 1.2.2

--- a/catalog/raw/vaultserver/vaultserver-1.2.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.3.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.2.3
   version: 1.2.3

--- a/catalog/raw/vaultserver/vaultserver-1.5.9.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.5.9.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.5.9
   version: 1.5.9

--- a/catalog/raw/vaultserver/vaultserver-1.6.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.6.5.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.6.5
   version: 1.6.5

--- a/catalog/raw/vaultserver/vaultserver-1.7.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.2.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.7.2
   version: 1.7.2

--- a/catalog/raw/vaultserver/vaultserver-1.7.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.3.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.7.3
   version: 1.7.3

--- a/catalog/raw/vaultserver/vaultserver-1.8.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.8.2.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.8.2
   version: 1.8.2

--- a/catalog/raw/vaultserver/vaultserver-1.9.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.9.2.yaml
@@ -12,7 +12,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.12.0
+    image: kubevault/vault-unsealer:v0.13.0
   vault:
     image: vault:1.9.2
   version: 1.9.2

--- a/charts/kubevault-catalog/Chart.yaml
+++ b/charts/kubevault-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Catalog by AppsCode - Catalog for KubeVault supported versions
 name: kubevault-catalog
-version: v2022.12.09
-appVersion: v2022.12.09
+version: v2022.12.28
+appVersion: v2022.12.28
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-catalog/README.md
+++ b/charts/kubevault-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-catalog --version=v2022.12.09
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.09
+$ helm search repo appscode/kubevault-catalog --version=v2022.12.28
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys HashiCorp KubeVault Catalog on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubevault-catalog`:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.09
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 The command deploys HashiCorp KubeVault Catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -58,12 +58,12 @@ The following table lists the configurable parameters of the `kubevault-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.09 --set image.registry=kubevault
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.28 --set image.registry=kubevault
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.09 --values values.yaml
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2022.12.28 --values values.yaml
 ```

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-0.11.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-0.11.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:0.11.5'
   version: 0.11.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.10.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.10.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.10.3'
   version: 1.10.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.11.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.11.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.11.5'
   version: 1.11.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.12.1.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.12.1.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.12.1'
   version: 1.12.1

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.0.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.0.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.2.0'
   version: 1.2.0

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.2.2'
   version: 1.2.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.2.3'
   version: 1.2.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.5.9.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.5.9.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.5.9'
   version: 1.5.9

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.6.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.6.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.6.5'
   version: 1.6.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.7.2'
   version: 1.7.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.7.3'
   version: 1.7.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.8.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.8.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.8.2'
   version: 1.8.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.9.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.9.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "kubevault") .Values) }}/vault-unsealer:v0.13.0'
   vault:
     image: '{{ include "official.registry" (merge (dict "_bin" "vault") .Values) }}:1.9.2'
   version: 1.9.2

--- a/charts/kubevault-crds/Chart.yaml
+++ b/charts/kubevault-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-crds
 description: KubeVault Custom Resource Definitions
 type: application
-version: v2022.12.09
-appVersion: v2022.12.09
+version: v2022.12.28
+appVersion: v2022.12.28
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-crds/README.md
+++ b/charts/kubevault-crds/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-crds --version=v2022.12.09
-$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2022.12.09
+$ helm search repo appscode/kubevault-crds --version=v2022.12.28
+$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeVault crds on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubevault-crds`:
 
 ```bash
-$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2022.12.09
+$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 The command deploys KubeVault crds on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubevault-metrics/Chart.yaml
+++ b/charts/kubevault-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-metrics
 description: KubeVault State Metrics
 type: application
-version: v2022.12.09
-appVersion: v2022.12.09
+version: v2022.12.28
+appVersion: v2022.12.28
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-community-icon.png
 sources:

--- a/charts/kubevault-metrics/README.md
+++ b/charts/kubevault-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-metrics --version=v2022.12.09
-$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kube-system --create-namespace --version=v2022.12.09
+$ helm search repo appscode/kubevault-metrics --version=v2022.12.28
+$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kube-system --create-namespace --version=v2022.12.28
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeVault metrics configurations on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubevault-metrics`:
 
 ```bash
-$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kube-system --create-namespace --version=v2022.12.09
+$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kube-system --create-namespace --version=v2022.12.28
 ```
 
 The command deploys KubeVault metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubevault-operator/Chart.yaml
+++ b/charts/kubevault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Operator by AppsCode - HashiCorp Vault operator for Kubernetes
 name: kubevault-operator
-version: v0.12.0
-appVersion: v0.12.0
+version: v0.13.0
+appVersion: v0.13.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-operator/README.md
+++ b/charts/kubevault-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-operator --version=v0.12.0
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.12.0
+$ helm search repo appscode/kubevault-operator --version=v0.13.0
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.13.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a HashiCorp Vault operator on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `kubevault-operator`:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.12.0
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.13.0
 ```
 
 The command deploys a HashiCorp Vault operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -86,12 +86,12 @@ The following table lists the configurable parameters of the `kubevault-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.12.0 --set replicaCount=1
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.13.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.12.0 --values values.yaml
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.13.0 --values values.yaml
 ```

--- a/charts/kubevault-webhook-server/Chart.yaml
+++ b/charts/kubevault-webhook-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Webhook Server by AppsCode
 name: kubevault-webhook-server
-version: v0.12.0
-appVersion: v0.12.0
+version: v0.13.0
+appVersion: v0.13.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-community-icon.png
 sources:

--- a/charts/kubevault-webhook-server/README.md
+++ b/charts/kubevault-webhook-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-webhook-server --version=v0.12.0
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.12.0
+$ helm search repo appscode/kubevault-webhook-server --version=v0.13.0
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.13.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault webhook server on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `kubevault-webhook-server`:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.12.0
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.13.0
 ```
 
 The command deploys a KubeVault webhook server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -89,12 +89,12 @@ The following table lists the configurable parameters of the `kubevault-webhook-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.12.0 --set replicaCount=1
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.13.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.12.0 --values values.yaml
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.13.0 --values values.yaml
 ```

--- a/charts/kubevault/Chart.lock
+++ b/charts/kubevault/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: kubevault-crds
   repository: file://../kubevault-crds
-  version: v2022.12.09
+  version: v2022.12.28
 - name: kubevault-catalog
   repository: file://../kubevault-catalog
-  version: v2022.12.09
+  version: v2022.12.28
 - name: kubevault-operator
   repository: file://../kubevault-operator
-  version: v0.12.0
+  version: v0.13.0
 - name: kubevault-webhook-server
   repository: file://../kubevault-webhook-server
-  version: v0.12.0
-digest: sha256:1f2eea329d230e2b82c0b13fb4bc1ac659ef78202695e8453051e74f4e89f517
-generated: "2022-12-09T15:03:40.502891841Z"
+  version: v0.13.0
+digest: sha256:98a144f2100ec153389ce3d458ec9625f405c564b52cc726d361f9ac38c32599
+generated: "2022-12-28T11:09:25.640579476Z"

--- a/charts/kubevault/Chart.yaml
+++ b/charts/kubevault/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault
 description: KubeVault by AppsCode - HashiCorp Vault operator for Kubernetes
 type: application
-version: v2022.12.09
-appVersion: v2022.12.09
+version: v2022.12.28
+appVersion: v2022.12.28
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-icon.png
 sources:
@@ -14,17 +14,17 @@ maintainers:
 dependencies:
 - name: kubevault-crds
   repository: file://../kubevault-crds
-  version: v2022.12.09
+  version: v2022.12.28
   condition: kubevault-crds.enabled
 - name: kubevault-catalog
   repository: file://../kubevault-catalog
-  version: v2022.12.09
+  version: v2022.12.28
   condition: kubevault-catalog.enabled
 - name: kubevault-operator
   repository: file://../kubevault-operator
-  version: v0.12.0
+  version: v0.13.0
   condition: kubevault-operator.enabled
 - name: kubevault-webhook-server
   repository: file://../kubevault-webhook-server
-  version: v0.12.0
+  version: v0.13.0
   condition: kubevault-webhook-server.enabled

--- a/charts/kubevault/README.md
+++ b/charts/kubevault/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault --version=v2022.12.09
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.09
+$ helm search repo appscode/kubevault --version=v2022.12.28
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault operator on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `kubevault`:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.09
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 The command deploys a KubeVault operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubevault` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.09 --set global.registry=kubevault
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.28 --set global.registry=kubevault
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.09 --values values.yaml
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2022.12.28 --values values.yaml
 ```

--- a/charts/secrets-store-reader/Chart.yaml
+++ b/charts/secrets-store-reader/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: secrets-store-reader
 description: A Helm chart for secrets-store-reader by AppsCode
 type: application
-version: v2022.12.09
-appVersion: v2022.12.09
+version: v2022.12.28
+appVersion: v2022.12.28
 home: https://github.com/kubevault/secrets-store-reader
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/secrets-store-reader/README.md
+++ b/charts/secrets-store-reader/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/secrets-store-reader --version=v2022.12.09
-$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.09
+$ helm search repo appscode/secrets-store-reader --version=v2022.12.28
+$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Secrets Store Reader api server on a [Kubernetes](http://ku
 To install/upgrade the chart with the release name `secrets-store-reader`:
 
 ```bash
-$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.09
+$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.28
 ```
 
 The command deploys a Secrets Store Reader api server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -84,12 +84,12 @@ The following table lists the configurable parameters of the `secrets-store-read
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.09 --set replicaCount=1
+$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.28 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.09 --values values.yaml
+$ helm upgrade -i secrets-store-reader appscode/secrets-store-reader -n kubevault --create-namespace --version=v2022.12.28 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2022.12.28
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>