### PR TITLE
Prepare for release v2025.2.6-rc.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ lint: $(BUILD_DIRS)
 	    --env GO111MODULE=on                                    \
 	    --env GOFLAGS="-mod=vendor"                             \
 	    $(BUILD_IMAGE)                                          \
-	    golangci-lint run --enable $(ADDTL_LINTERS) --timeout=10m --skip-files="generated.*\.go$\" --skip-dirs-use-default --skip-dirs=client,vendor
+	    golangci-lint run --enable $(ADDTL_LINTERS) --timeout=10m --exclude-files="generated.*\.go$\" --exclude-dirs-use-default --exclude-dirs=client,vendor
 
 $(BUILD_DIRS):
 	@mkdir -p $@

--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -36,8 +36,8 @@ mv /tmp/crane .
 CMD="./crane"
 
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-exporter:v0.1.1 $IMAGE_REGISTRY/kubevault/vault-exporter:v0.1.1
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-operator:v0.19.0 $IMAGE_REGISTRY/kubevault/vault-operator:v0.19.0
-$CMD cp --allow-nondistributable-artifacts --insecure kubevault/vault-unsealer:v0.19.0 $IMAGE_REGISTRY/kubevault/vault-unsealer:v0.19.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-operator:v0.20.0-rc.0 $IMAGE_REGISTRY/kubevault/vault-operator:v0.20.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure kubevault/vault-unsealer:v0.20.0-rc.0 $IMAGE_REGISTRY/kubevault/vault-unsealer:v0.20.0-rc.0
 $CMD cp --allow-nondistributable-artifacts --insecure vault:0.11.5 $IMAGE_REGISTRY/vault:0.11.5
 $CMD cp --allow-nondistributable-artifacts --insecure vault:1.10.3 $IMAGE_REGISTRY/vault:1.10.3
 $CMD cp --allow-nondistributable-artifacts --insecure vault:1.11.5 $IMAGE_REGISTRY/vault:1.11.5

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -33,8 +33,8 @@ mv /tmp/crane images
 CMD="./images/crane"
 
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-exporter:v0.1.1 images/kubevault-vault-exporter-v0.1.1.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-operator:v0.19.0 images/kubevault-vault-operator-v0.19.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure kubevault/vault-unsealer:v0.19.0 images/kubevault-vault-unsealer-v0.19.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubevault/vault-operator:v0.20.0-rc.0 images/kubevault-vault-operator-v0.20.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure kubevault/vault-unsealer:v0.20.0-rc.0 images/kubevault-vault-unsealer-v0.20.0-rc.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure vault:0.11.5 images/library-vault-0.11.5.tar
 $CMD pull --allow-nondistributable-artifacts --insecure vault:1.10.3 images/library-vault-1.10.3.tar
 $CMD pull --allow-nondistributable-artifacts --insecure vault:1.11.5 images/library-vault-1.11.5.tar

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -1,6 +1,6 @@
 - ghcr.io/kubevault/vault-exporter:v0.1.1
-- ghcr.io/kubevault/vault-operator:v0.19.0
-- kubevault/vault-unsealer:v0.19.0
+- ghcr.io/kubevault/vault-operator:v0.20.0-rc.0
+- kubevault/vault-unsealer:v0.20.0-rc.0
 - vault:0.11.5
 - vault:1.10.3
 - vault:1.11.5

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -27,8 +27,8 @@ tar -zxvf $TARBALL
 CMD="./crane"
 
 $CMD push --allow-nondistributable-artifacts --insecure images/kubevault-vault-exporter-v0.1.1.tar $IMAGE_REGISTRY/kubevault/vault-exporter:v0.1.1
-$CMD push --allow-nondistributable-artifacts --insecure images/kubevault-vault-operator-v0.19.0.tar $IMAGE_REGISTRY/kubevault/vault-operator:v0.19.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubevault-vault-unsealer-v0.19.0.tar $IMAGE_REGISTRY/kubevault/vault-unsealer:v0.19.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubevault-vault-operator-v0.20.0-rc.0.tar $IMAGE_REGISTRY/kubevault/vault-operator:v0.20.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubevault-vault-unsealer-v0.20.0-rc.0.tar $IMAGE_REGISTRY/kubevault/vault-unsealer:v0.20.0-rc.0
 $CMD push --allow-nondistributable-artifacts --insecure images/library-vault-0.11.5.tar $IMAGE_REGISTRY/vault:0.11.5
 $CMD push --allow-nondistributable-artifacts --insecure images/library-vault-1.10.3.tar $IMAGE_REGISTRY/vault:1.10.3
 $CMD push --allow-nondistributable-artifacts --insecure images/library-vault-1.11.5.tar $IMAGE_REGISTRY/vault:1.11.5

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -25,8 +25,8 @@ TARBALL=${1:-}
 tar -zxvf $TARBALL
 
 k3s ctr images import images/kubevault-vault-exporter-v0.1.1.tar
-k3s ctr images import images/kubevault-vault-operator-v0.19.0.tar
-k3s ctr images import images/kubevault-vault-unsealer-v0.19.0.tar
+k3s ctr images import images/kubevault-vault-operator-v0.20.0-rc.0.tar
+k3s ctr images import images/kubevault-vault-unsealer-v0.20.0-rc.0.tar
 k3s ctr images import images/library-vault-0.11.5.tar
 k3s ctr images import images/library-vault-1.10.3.tar
 k3s ctr images import images/library-vault-1.11.5.tar

--- a/catalog/raw/vaultserver/vaultserver-0.11.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-0.11.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:0.11.5
   version: 0.11.5

--- a/catalog/raw/vaultserver/vaultserver-1.10.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.10.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.10.3
   version: 1.10.3

--- a/catalog/raw/vaultserver/vaultserver-1.11.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.11.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.11.5
   version: 1.11.5

--- a/catalog/raw/vaultserver/vaultserver-1.12.1.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.12.1.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.12.1
   version: 1.12.1

--- a/catalog/raw/vaultserver/vaultserver-1.13.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.13.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.13.3
   version: 1.13.3

--- a/catalog/raw/vaultserver/vaultserver-1.2.0.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.0.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.2.0
   version: 1.2.0

--- a/catalog/raw/vaultserver/vaultserver-1.2.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.2.2
   version: 1.2.2

--- a/catalog/raw/vaultserver/vaultserver-1.2.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.2.3
   version: 1.2.3

--- a/catalog/raw/vaultserver/vaultserver-1.5.9.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.5.9.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.5.9
   version: 1.5.9

--- a/catalog/raw/vaultserver/vaultserver-1.6.5.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.6.5.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.6.5
   version: 1.6.5

--- a/catalog/raw/vaultserver/vaultserver-1.7.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.7.2
   version: 1.7.2

--- a/catalog/raw/vaultserver/vaultserver-1.7.3.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.3.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.7.3
   version: 1.7.3

--- a/catalog/raw/vaultserver/vaultserver-1.8.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.8.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.8.2
   version: 1.8.2

--- a/catalog/raw/vaultserver/vaultserver-1.9.2.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.9.2.yaml
@@ -14,7 +14,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: kubevault/vault-unsealer:v0.19.0
+    image: kubevault/vault-unsealer:v0.20.0-rc.0
   vault:
     image: vault:1.9.2
   version: 1.9.2

--- a/charts/kubevault-catalog/Chart.yaml
+++ b/charts/kubevault-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Catalog by AppsCode - Catalog for KubeVault supported versions
 name: kubevault-catalog
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-catalog/README.md
+++ b/charts/kubevault-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-catalog --version=v2024.9.30
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault-catalog --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys HashiCorp KubeVault Catalog on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubevault-catalog`:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys HashiCorp KubeVault Catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -60,12 +60,12 @@ The following table lists the configurable parameters of the `kubevault-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2024.9.30 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2025.2.6-rc.0 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2024.9.30 --values values.yaml
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-0.11.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-0.11.5.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:0.11.5'
   version: 0.11.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.10.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.10.3.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.10.3'
   version: 1.10.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.11.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.11.5.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.11.5'
   version: 1.11.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.12.1.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.12.1.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.12.1'
   version: 1.12.1

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.13.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.13.3.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.13.3'
   version: 1.13.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.0.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.0.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.2.0'
   version: 1.2.0

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.2.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.2.2'
   version: 1.2.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.2.3.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.2.3'
   version: 1.2.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.5.9.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.5.9.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.5.9'
   version: 1.5.9

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.6.5.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.6.5.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.6.5'
   version: 1.6.5

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.2.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.7.2'
   version: 1.7.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.3.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.7.3.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.7.3'
   version: 1.7.3

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.8.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.8.2.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.8.2'
   version: 1.8.2

--- a/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.9.2.yaml
+++ b/charts/kubevault-catalog/templates/vaultserver/vaultserver-1.9.2.yaml
@@ -16,7 +16,7 @@ spec:
       restoreTask:
         name: vault-restore-1.10.3
   unsealer:
-    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.19.0'
+    image: '{{ include "image.dockerHub" (merge (dict "_repo" "kubevault/vault-unsealer") $) }}:v0.20.0-rc.0'
   vault:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "vault") $) }}:1.9.2'
   version: 1.9.2

--- a/charts/kubevault-crds/Chart.yaml
+++ b/charts/kubevault-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-crds
 description: KubeVault Custom Resource Definitions
 type: application
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-crds/README.md
+++ b/charts/kubevault-crds/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-crds --version=v2024.9.30
-$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault-crds --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeVault crds on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubevault-crds`:
 
 ```bash
-$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault-crds appscode/kubevault-crds -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys KubeVault crds on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
@@ -10167,7 +10167,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the
@@ -21208,7 +21209,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the

--- a/charts/kubevault-crds/crds/ops.kubevault.com_vaultopsrequests.yaml
+++ b/charts/kubevault-crds/crds/ops.kubevault.com_vaultopsrequests.yaml
@@ -126,7 +126,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the

--- a/charts/kubevault-grafana-dashboards/Chart.yaml
+++ b/charts/kubevault-grafana-dashboards/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-grafana-dashboards
 description: A Helm chart for kubevault-grafana-dashboards by AppsCode
 type: application
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://github.com/kubevault
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-icon.png
 sources:

--- a/charts/kubevault-grafana-dashboards/README.md
+++ b/charts/kubevault-grafana-dashboards/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-grafana-dashboards --version=v2024.9.30
-$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault-grafana-dashboards --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault Grafana Dashboards on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `kubevault-grafana-dashboards`:
 
 ```bash
-$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys a KubeVault Grafana Dashboards on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubevault-grafana-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2024.9.30 --set resources=["vaultserver"]
+$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2025.2.6-rc.0 --set resources=["vaultserver"]
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2024.9.30 --values values.yaml
+$ helm upgrade -i kubevault-grafana-dashboards appscode/kubevault-grafana-dashboards -n kubeops --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```

--- a/charts/kubevault-metrics/Chart.yaml
+++ b/charts/kubevault-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-metrics
 description: KubeVault State Metrics
 type: application
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-community-icon.png
 sources:

--- a/charts/kubevault-metrics/README.md
+++ b/charts/kubevault-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-metrics --version=v2024.9.30
-$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kubevault --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault-metrics --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeVault metrics configurations on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubevault-metrics`:
 
 ```bash
-$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kubevault --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault-metrics appscode/kubevault-metrics -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys KubeVault metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubevault-operator/Chart.yaml
+++ b/charts/kubevault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Operator by AppsCode - HashiCorp Vault operator for Kubernetes
 name: kubevault-operator
-version: v0.19.0
-appVersion: v0.19.0
+version: v0.20.0-rc.0
+appVersion: v0.20.0-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/icons/android-icon-192x192.png
 sources:

--- a/charts/kubevault-operator/README.md
+++ b/charts/kubevault-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-operator --version=v0.19.0
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.19.0
+$ helm search repo appscode/kubevault-operator --version=v0.20.0-rc.0
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.20.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a HashiCorp Vault operator on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `kubevault-operator`:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.19.0
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.20.0-rc.0
 ```
 
 The command deploys a HashiCorp Vault operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -87,12 +87,12 @@ The following table lists the configurable parameters of the `kubevault-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.19.0 --set replicaCount=1
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.20.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.19.0 --values values.yaml
+$ helm upgrade -i kubevault-operator appscode/kubevault-operator -n kubevault --create-namespace --version=v0.20.0-rc.0 --values values.yaml
 ```

--- a/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
@@ -10167,7 +10167,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the
@@ -21208,7 +21209,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the

--- a/charts/kubevault-opscenter/Chart.lock
+++ b/charts/kubevault-opscenter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubevault-metrics
   repository: file://../kubevault-metrics
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: kubevault-grafana-dashboards
   repository: file://../kubevault-grafana-dashboards
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   version: v2024.9.30
-digest: sha256:398c9fdad7eb30aba5703473cbdf1d2d301a38482f22ac7fba945270e4158d47
-generated: "2025-02-01T00:41:07.819835+06:00"
+digest: sha256:b018a8bbe929ddc6a7b720ee35c2f80df33d8b14c57efcf349592bee2d8c3db3
+generated: "2025-02-06T22:52:11.603157522Z"

--- a/charts/kubevault-opscenter/Chart.yaml
+++ b/charts/kubevault-opscenter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault-opscenter
 description: KubeVault Opscenter by AppsCode
 type: application
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-icon.png
 sources:
@@ -15,11 +15,11 @@ dependencies:
 - name: kubevault-metrics
   repository: file://../kubevault-metrics
   condition: kubevault-metrics.enabled
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: kubevault-grafana-dashboards
   repository: file://../kubevault-grafana-dashboards
   condition: kubevault-grafana-dashboards.enabled
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   condition: ace-user-roles.enabled

--- a/charts/kubevault-opscenter/README.md
+++ b/charts/kubevault-opscenter/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-opscenter --version=v2024.9.30
-$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault-opscenter --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault Opscenter on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `kubevault-opscenter`:
 
 ```bash
-$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys a KubeVault Opscenter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -73,12 +73,12 @@ The following table lists the configurable parameters of the `kubevault-opscente
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2024.9.30 --set global.registryFQDN=ghcr.io
+$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2025.2.6-rc.0 --set global.registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2024.9.30 --values values.yaml
+$ helm upgrade -i kubevault-opscenter appscode/kubevault-opscenter -n kubevault --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```

--- a/charts/kubevault-webhook-server/Chart.yaml
+++ b/charts/kubevault-webhook-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeVault Webhook Server by AppsCode
 name: kubevault-webhook-server
-version: v0.19.0
-appVersion: v0.19.0
+version: v0.20.0-rc.0
+appVersion: v0.20.0-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-community-icon.png
 sources:

--- a/charts/kubevault-webhook-server/README.md
+++ b/charts/kubevault-webhook-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault-webhook-server --version=v0.19.0
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.19.0
+$ helm search repo appscode/kubevault-webhook-server --version=v0.20.0-rc.0
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.20.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault webhook server on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `kubevault-webhook-server`:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.19.0
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.20.0-rc.0
 ```
 
 The command deploys a KubeVault webhook server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -89,12 +89,12 @@ The following table lists the configurable parameters of the `kubevault-webhook-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.19.0 --set replicaCount=1
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.20.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.19.0 --values values.yaml
+$ helm upgrade -i kubevault-webhook-server appscode/kubevault-webhook-server -n kubevault --create-namespace --version=v0.20.0-rc.0 --values values.yaml
 ```

--- a/charts/kubevault/Chart.lock
+++ b/charts/kubevault/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: kubevault-crds
   repository: file://../kubevault-crds
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: kubevault-catalog
   repository: file://../kubevault-catalog
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
 - name: kubevault-operator
   repository: file://../kubevault-operator
-  version: v0.19.0
+  version: v0.20.0-rc.0
 - name: kubevault-webhook-server
   repository: file://../kubevault-webhook-server
-  version: v0.19.0
+  version: v0.20.0-rc.0
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   version: v2024.9.30
-digest: sha256:3897b63f14afda551dcfffc14290e42ac52620fda9e93c2bd706a7389cb056fc
-generated: "2025-02-01T00:41:03.176143+06:00"
+digest: sha256:cb970a973a6ec32beb9e6d095834c15025850341b4f2a6e9e418315895c43bc2
+generated: "2025-02-06T22:52:10.786818799Z"

--- a/charts/kubevault/Chart.yaml
+++ b/charts/kubevault/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevault
 description: KubeVault by AppsCode - HashiCorp Vault operator for Kubernetes
 type: application
-version: v2024.9.30
-appVersion: v2024.9.30
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubevault.com
 icon: https://cdn.appscode.com/images/products/kubevault/kubevault-icon.png
 sources:
@@ -14,19 +14,19 @@ maintainers:
 dependencies:
 - name: kubevault-crds
   repository: file://../kubevault-crds
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
   condition: kubevault-crds.enabled
 - name: kubevault-catalog
   repository: file://../kubevault-catalog
-  version: v2024.9.30
+  version: v2025.2.6-rc.0
   condition: kubevault-catalog.enabled
 - name: kubevault-operator
   repository: file://../kubevault-operator
-  version: v0.19.0
+  version: v0.20.0-rc.0
   condition: kubevault-operator.enabled
 - name: kubevault-webhook-server
   repository: file://../kubevault-webhook-server
-  version: v0.19.0
+  version: v0.20.0-rc.0
   condition: kubevault-webhook-server.enabled
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts

--- a/charts/kubevault/README.md
+++ b/charts/kubevault/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubevault --version=v2024.9.30
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2024.9.30
+$ helm search repo appscode/kubevault --version=v2025.2.6-rc.0
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeVault operator on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `kubevault`:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2024.9.30
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys a KubeVault operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -75,12 +75,12 @@ The following table lists the configurable parameters of the `kubevault` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2024.9.30 --set global.registry=kubevault
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2025.2.6-rc.0 --set global.registry=kubevault
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2024.9.30 --values values.yaml
+$ helm upgrade -i kubevault appscode/kubevault -n kubevault --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```

--- a/crds/kubevault-crds.yaml
+++ b/crds/kubevault-crds.yaml
@@ -13191,7 +13191,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the
@@ -24232,7 +24233,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the
@@ -24794,7 +24796,8 @@ spec:
                               type: string
                           type: object
                         renewBefore:
-                          description: Certificate renew before expiration duration
+                          description: "Certificate renew before expiration duration
+                            \n Deprecated use `ReconfigureTLS` type OpsRequest instead."
                           type: string
                         secretName:
                           description: Specifies the k8s secret name that holds the


### PR DESCRIPTION
ProductLine: KubeVault
Release: v2025.2.6-rc.0
Release-tracker: https://github.com/kubevault/CHANGELOG/pull/55
Signed-off-by: 1gtm <1gtm@appscode.com>