### PR TITLE
Updates for running vault server in openshift

### DIFF
--- a/charts/kubevault-operator/templates/cluster-role.yaml
+++ b/charts/kubevault-operator/templates/cluster-role.yaml
@@ -51,6 +51,11 @@ rules:
   - serviceaccounts
   verbs: ["create", "get", "patch"]
 - apiGroups:
+    - ""
+  resources:
+    - serviceaccounts/finalizers
+  verbs: ["update"]
+- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
Solves the following permission issue:

```
I0218 13:46:10.098967       1 worker.go:97] Error syncing key demo/vault: for VaultServer demo/vault: failed to deploy vault: secrets "vault-token-f2hcm4" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```