### PR TITLE
Remove bzr install from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Prepare Host
         run: |
-          sudo apt-get -qq update || true
-          sudo apt-get install -y bzr
           # install yq
           curl -fsSL -o yqq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
           chmod +x yqq


### PR DESCRIPTION
Drop sudo apt-get install -y bzr (and the preceding apt-get update) — no longer needed.