### PR TITLE
Chart follow-ups for operator PR #182: --register-crds + VaultServer conversion webhook

### DIFF
--- a/charts/kubevault-operator/templates/cluster-role.yaml
+++ b/charts/kubevault-operator/templates/cluster-role.yaml
@@ -105,7 +105,7 @@ rules:
   - clusterrolebindings
   - roles
   - rolebindings
-  verbs: ["get", "update", "create", "patch", "delete"]
+  verbs: ["watch", "list", "get", "update", "create", "patch", "delete"]
 - apiGroups:
   - cert-manager.io
   resources:

--- a/charts/kubevault-operator/templates/deployment.yaml
+++ b/charts/kubevault-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         - --cluster-name={{ .Values.clusterName }}
         - --metrics-bind-address=:{{ .Values.monitoring.bindPort }}
         - --health-probe-bind-address=:{{ .Values.apiserver.healthcheck.probePort }}
+        {{- if .Values.operator.registerCRDs }}
+        - --register-crds=true
+        {{- end }}
         {{- with .Values.recommendationEngine }}
         - --recommendation-resync-period={{ .recommendationResyncPeriod }}
         - --gen-rotate-tls-recommendation-before-expiry-year={{ .genRotateTLSRecommendationBeforeExpiryYear }}

--- a/charts/kubevault-operator/values.yaml
+++ b/charts/kubevault-operator/values.yaml
@@ -46,6 +46,11 @@ operator:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+  # If true, the operator applies its CustomResourceDefinitions at
+  # startup. Defaults to false because the kubevault-crds subchart
+  # (or its standalone equivalent) installs the CRDs; only enable
+  # this for single-chart installs where kubevault-crds is absent.
+  registerCRDs: false
 
 # Specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.

--- a/charts/kubevault-webhook-server/templates/webhooks.yaml
+++ b/charts/kubevault-webhook-server/templates/webhooks.yaml
@@ -255,3 +255,92 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 10
 {{- end }}
+
+{{- /* ---- VaultServer CRD conversion (v1alpha1 <-> v1alpha2) ---- */ -}}
+{{- /*
+The vaultservers.kubevault.com CRD ships in the kubevault-crds chart
+without a conversion strategy, so we patch spec.conversion at install /
+upgrade time. The patch is rendered here so it shares the $caCrt
+computed at the top of this file; it then gets applied by a kubectl
+Job (post-install,post-upgrade hook). In cert-manager mode the caBundle
+is left out and cert-manager's ca-injector populates it via the
+metadata annotation. The webhook-server ServiceAccount already has
+"customresourcedefinitions: *" via cluster-role.yaml so no extra RBAC
+is needed.
+*/ -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-vaultservers-conversion
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubevault-webhook-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  patch.yaml: |
+    {{- if $useCertManager }}
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from-secret: {{ printf "%s/%s-apiserver-cert" $svcNamespace $fullname }}
+    {{- end }}
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          conversionReviewVersions: ["v1"]
+          clientConfig:
+            service:
+              namespace: {{ $svcNamespace }}
+              name: {{ $fullname }}
+              path: /convert
+              port: 443
+            {{- if not $useCertManager }}
+            caBundle: {{ $caCrt }}
+            {{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullname }}-vaultservers-conversion-patch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubevault-webhook-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "kubevault-webhook-server.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "appscode.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "kubevault-webhook-server.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+      - name: kubectl
+        image: {{ .Values.kubectl.registry }}/{{ .Values.kubectl.repository }}:{{ .Values.kubectl.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          kubectl patch crd vaultservers.kubevault.com \
+            --type=merge \
+            --patch-file=/patch/patch.yaml
+        volumeMounts:
+        - name: patch
+          mountPath: /patch
+          readOnly: true
+      volumes:
+      - name: patch
+        configMap:
+          name: {{ $fullname }}-vaultservers-conversion

--- a/charts/kubevault-webhook-server/values.yaml
+++ b/charts/kubevault-webhook-server/values.yaml
@@ -123,3 +123,12 @@ monitoring:
 distro:
   openshift: false
   ubi: ""
+
+# Settings for the post-install/post-upgrade Job that patches the VaultServer
+# CRD's spec.conversion to point at this webhook server. The Job runs once
+# per helm install / upgrade and is then garbage-collected.
+kubectl:
+  # kubectl image used by the conversion-patch Job
+  registry: docker.io/bitnami
+  repository: kubectl
+  tag: "1.31.4"


### PR DESCRIPTION
Stacks on top of #444 (kubebuilder-webhook-chart). Pairs with [kubevault/operator#182](https://github.com/kubevault/operator/pull/182).

## Summary
Two chart-side changes triggered by Phase 8 of the operator's kubebuilder migration.

### 1. \`kubevault-operator\`: \`operator.registerCRDs\` knob (default false)

The operator binary in #182 added a \`--register-crds\` flag, defaulting to false, so the operator pod no longer applies CRDs at startup in production. The chart now mirrors that with a new value (\`operator.registerCRDs\`); production installs leave it off and rely on the \`kubevault-crds\` subchart. Single-chart installs that lack \`kubevault-crds\` can opt back in:

\`\`\`yaml
operator:
  registerCRDs: true
\`\`\`

### 2. \`kubevault-webhook-server\`: VaultServer CRD conversion webhook

The \`vaultservers.kubevault.com\` CRD ships in \`kubevault-crds\` with two versions (\`v1alpha1\`, \`v1alpha2\`) but no \`spec.conversion\` block, so the apiserver currently does an identity field-mirror between them. The operator-side PR #182 now formally hosts \`/convert\` via the WebhookBuilder (\`v1alpha2\` is the Hub, \`v1alpha1\` the Convertible), but nothing was telling the apiserver to call it.

This PR patches the CRD at install/upgrade time via a Helm post-install/post-upgrade Job:

- A ConfigMap \`<fullname>-vaultservers-conversion\` carries the patch payload (\`spec.conversion\` pointing at the webhook service's \`/convert\` path, with the caBundle inlined).
- A Job \`<fullname>-vaultservers-conversion-patch\` runs as the existing webhook-server ServiceAccount (which already has \`customresourcedefinitions: *\` via \`cluster-role.yaml\`) and applies the patch with \`kubectl patch crd ... --type=merge --patch-file=/patch/patch.yaml\`.
- Both objects live in \`webhooks.yaml\` so they share the single \`\$caCrt\` computed once per render (same constraint that drove webhooks.yaml's existing one-file layout — helm's \`genCA\` is non-deterministic across renders).
- In cert-manager mode the caBundle is omitted and a \`cert-manager.io/inject-ca-from-secret\` annotation is added to the CRD metadata instead so cert-manager's ca-injector populates it.
- New \`kubectl.{registry,repository,tag}\` values block; default \`bitnami/kubectl:1.31.4\`.

The Job is bounded (\`ttlSecondsAfterFinished: 60\`, \`backoffLimit: 3\`) and uses \`hook-delete-policy: before-hook-creation,hook-succeeded\` so leftover ConfigMaps/Jobs don't accumulate across upgrades.

## Test plan
- [x] \`helm lint charts/kubevault-webhook-server charts/kubevault-operator\` clean
- [x] \`helm template charts/kubevault-webhook-server/\` renders the Job + ConfigMap with the same caBundle as webhooks.yaml
- [x] \`helm template ... --set apiserver.servingCerts.certManager.enabled=true\` renders the cert-manager annotation form (no inline caBundle)
- [x] \`helm template charts/kubevault-operator/ --set operator.registerCRDs=true\` adds \`--register-crds=true\` to the deployment args; default omits it
- [ ] \`helm install\` end-to-end on a real cluster (kind/minikube) — confirm the Job completes and \`kubectl get crd vaultservers.kubevault.com -o yaml\` shows \`spec.conversion.strategy: Webhook\`
- [ ] Create a v1alpha1 VaultServer and confirm it's persisted as v1alpha2 (round-trip through the conversion webhook)
- [ ] \`helm upgrade\` — confirm the patch is re-applied and the ConfigMap/Job are recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)