### PR TITLE
Add docker.io prefix to Docker Hub images

### DIFF
--- a/catalog/raw/vaultserver/vaultserver-0.11.5-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-0.11.5-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:
@@ -17,5 +17,5 @@ spec:
   unsealer:
     image: ghcr.io/kubevault/vault-unsealer:v0.25.0-rc.1
   vault:
-    image: vault:0.11.5
+    image: docker.io/library/vault:0.11.5
   version: 0.11.5

--- a/catalog/raw/vaultserver/vaultserver-1.10.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.10.3-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.11.5-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.11.5-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.12.1-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.12.1-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.13.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.13.3-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.14.10-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.14.10-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.15.6-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.15.6-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.16.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.16.3-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.17.6-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.17.6-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.18.4-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.18.4-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.2.0-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.0-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.2.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.2-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.2.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.3-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.5.9-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.5.9-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.6.5-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.6.5-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.7.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.2-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.7.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.3-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.8.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.8.2-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-1.9.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.9.2-vault.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:

--- a/catalog/raw/vaultserver/vaultserver-2.4.3-openbao.yaml
+++ b/catalog/raw/vaultserver/vaultserver-2.4.3-openbao.yaml
@@ -7,7 +7,7 @@ spec:
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:
-    image: busybox
+    image: docker.io/library/busybox
   stash:
     addon:
       backupTask:
@@ -17,5 +17,5 @@ spec:
   unsealer:
     image: ghcr.io/kubevault/vault-unsealer:v0.25.0-rc.1
   vault:
-    image: openbao/openbao:2.4.3
+    image: docker.io/openbao/openbao:2.4.3
   version: 2.4.3

--- a/charts/kubevault-catalog/README.md
+++ b/charts/kubevault-catalog/README.md
@@ -49,8 +49,8 @@ The following table lists the configurable parameters of the `kubevault-catalog`
 |-----------------------|-------------------------------------------------|--------------------------------|
 | nameOverride          | Overrides name template                         | <code>""</code>                |
 | fullnameOverride      | Overrides fullname template                     | <code>""</code>                |
-| proxies.dockerHub     |                                                 | <code>""</code>                |
-| proxies.dockerLibrary |                                                 | <code>""</code>                |
+| proxies.dockerHub     |                                                 | <code>docker.io</code>         |
+| proxies.dockerLibrary |                                                 | <code>docker.io/library</code> |
 | proxies.ghcr          |                                                 | <code>ghcr.io</code>           |
 | proxies.quay          |                                                 | <code>quay.io</code>           |
 | proxies.kubernetes    |                                                 | <code>registry.k8s.io</code>   |
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the `kubevault-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2026.5.18-rc.1 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubevault-catalog appscode/kubevault-catalog -n kubevault --create-namespace --version=v2026.5.18-rc.1 --set proxies.dockerHub=docker.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while

--- a/charts/kubevault-catalog/values.yaml
+++ b/charts/kubevault-catalog/values.yaml
@@ -8,8 +8,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 proxies:
-  dockerHub: ""
-  dockerLibrary: ""
+  dockerHub: docker.io
+  dockerLibrary: docker.io/library
   ghcr: ghcr.io
   quay: quay.io
   kubernetes: registry.k8s.io

--- a/hack/fmt/main.go
+++ b/hack/fmt/main.go
@@ -50,6 +50,11 @@ var ubiImageList = sets.NewString(
 	"ghcr.io/kubevault/vault-unsealer",
 )
 
+var imagePathList = [][]string{
+	{"image"},
+	{"initContainer", "image"},
+}
+
 type AppVersion struct {
 	Group   string
 	Kind    string
@@ -200,7 +205,44 @@ func main() {
 		}
 	}
 
+	// FORMAT CATALOG, INJECT docker.io prefix
 	for k, v := range appStore {
+		for _, obj := range v {
+			spec, _, err := unstructured.NestedMap(obj.Object, "spec")
+			if err != nil {
+				panic(err)
+			}
+			for prop := range spec {
+				updateDockerHubPrefix := func(fields ...string) {
+					fieldList := append([]string{"spec", prop}, fields...)
+					img, ok, _ := unstructured.NestedString(obj.Object, fieldList...)
+					if img != "" && ok {
+						ref, err := name.ParseReference(img)
+						if err != nil {
+							panic(err)
+						}
+
+						if ref.Registry == "index.docker.io" && !strings.HasPrefix(img, "docker.io/") {
+							if _, digest, found := strings.Cut(img, "@"); found {
+								img = fmt.Sprintf("docker.io/%s@%s", ref.Repository, digest)
+							} else if _, tag, found := strings.Cut(img, ":"); found {
+								img = fmt.Sprintf("docker.io/%s:%s", ref.Repository, tag)
+							} else {
+								img = fmt.Sprintf("docker.io/%s", ref.Repository)
+							}
+						}
+						err = unstructured.SetNestedField(obj.Object, img, fieldList...)
+						if err != nil {
+							panic(err)
+						}
+					}
+				}
+				for _, path := range imagePathList {
+					updateDockerHubPrefix(path...)
+				}
+			}
+		}
+
 		sort.Slice(v, func(i, j int) bool {
 			di, _, _ := unstructured.NestedBool(v[i].Object, "spec", "deprecated")
 			dj, _, _ := unstructured.NestedBool(v[j].Object, "spec", "deprecated")
@@ -273,8 +315,9 @@ func main() {
 					panic(err)
 				}
 				for prop := range spec {
-					templatizeRegistry := func(field string) {
-						img, ok, _ := unstructured.NestedString(obj.Object, "spec", prop, field)
+					templatizeRegistry := func(fields ...string) {
+						fieldList := append([]string{"spec", prop}, fields...)
+						img, ok, _ := unstructured.NestedString(obj.Object, fieldList...)
 						if ok {
 							ref, err := name.ParseReference(img)
 							if err != nil {
@@ -303,14 +346,15 @@ func main() {
 									newimg += `{{ include "catalog.ubi" $ }}`
 								}
 							}
-							err = unstructured.SetNestedField(obj.Object, newimg, "spec", prop, field)
+							err = unstructured.SetNestedField(obj.Object, newimg, fieldList...)
 							if err != nil {
 								panic(err)
 							}
 						}
 					}
-					templatizeRegistry("image")
-					templatizeRegistry("yqImage")
+					for _, path := range imagePathList {
+						templatizeRegistry(path...)
+					}
 				}
 
 				if i > 0 {


### PR DESCRIPTION
## Summary

Mirrors [kubedb/installer#2168](https://github.com/kubedb/installer/pull/2168) for the kubevault catalog formatter:

- Consolidate image field paths into `imagePathList` and refactor `templatizeRegistry` to use it.
- New "FORMAT CATALOG, INJECT docker.io prefix" pass rewrites Docker Hub images in `catalog/raw/vaultserver/*.yaml` to their `docker.io/...` form so the raw catalog matches the helm-rendered output.
- Extended the prefix logic with an `else` branch for untagged images (e.g. `busybox` → `docker.io/library/busybox`), needed because kubevault catalogs ship untagged `busybox` — clears a pre-existing verifier mismatch.
- Set `proxies.dockerHub: docker.io` and `proxies.dockerLibrary: docker.io/library` defaults in `kubevault-catalog/values.yaml` (regenerated README).

Oracle registry and MySQL-specific bits from PR #2168 are intentionally omitted (not relevant to kubevault).

## Test plan
- [x] `go run ./hack/fmt/main.go` exits 0 (verifier passes).
- [ ] `make ci` in CI.