### PR TITLE
catalog: mark pre-1.10 Vault versions as deprecated

### DIFF
--- a/catalog/raw/vaultserver/vaultserver-0.11.5-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-0.11.5-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 0.11.5
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.2.0-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.0-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.2.0
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.2.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.2-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.2.2
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.2.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.2.3-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.2.3
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.5.9-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.5.9-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.5.9
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.6.5-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.6.5-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.6.5
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.7.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.2-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.7.2
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.7.3-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.7.3-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.7.3
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.8.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.8.2-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.8.2
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:

--- a/catalog/raw/vaultserver/vaultserver-1.9.2-vault.yaml
+++ b/catalog/raw/vaultserver/vaultserver-1.9.2-vault.yaml
@@ -4,6 +4,7 @@ metadata:
   name: 1.9.2
 spec:
   distribution: Vault
+  deprecated: true
   exporter:
     image: ghcr.io/kubevault/vault-exporter:v0.1.1
   initContainer:


### PR DESCRIPTION
Set `spec.deprecated=true` on every `VaultServerVersion` catalog entry older than 1.10:

- 0.11.5, 1.2.0, 1.2.2, 1.2.3, 1.5.9, 1.6.5, 1.7.2, 1.7.3, 1.8.2, 1.9.2

1.10.3+ and the OpenBao 2.4.3 entry are unaffected.

These versions predate the `GET sys/mounts/<path>` per-mount read endpoint that the operator now uses for secret-engine/database mount existence checks (replacing the full `sys/mounts` list). They remain usable but are best avoided; the `deprecated` flag surfaces as the `Deprecated` printer column on `kubectl get vaultserverversion`.