### PR TITLE
Rename VaultAgent to VaultRelay in charts/CRDs (agent->relay)

### DIFF
--- a/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-certified-crds/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-certified-crds/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-operator/templates/cluster-role.yaml
+++ b/charts/kubevault-operator/templates/cluster-role.yaml
@@ -141,7 +141,7 @@ rules:
   - clusterclaims
   verbs: ["get"]
   resourceNames: ["features.ace.info"]
-# OCM hub-driven spoke agent placement (VaultServer spec.agentPlacementRef):
+# OCM hub-driven spoke relay placement (VaultServer spec.relayPlacementRef):
 # resolve Placements through PlacementDecisions and maintain one ManifestWork
 # per selected managed cluster. The operator also creates ServiceAccounts and
 # Secrets in the managed cluster namespaces on the hub (covered by the core

--- a/crds/kubevault-crds.yaml
+++ b/crds/kubevault-crds.yaml
@@ -1973,7 +1973,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -1981,12 +1981,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -9602,7 +9602,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -9751,14 +9751,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -17448,7 +17448,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32


### PR DESCRIPTION
Applies the [apimachinery#158](https://github.com/kubevault/apimachinery/pull/158) rename (merged) to the installer charts.

## Changes
- CRD `kubevault.com_vaultagents.yaml` → `kubevault.com_vaultrelays.yaml` (kind `VaultAgent`→`VaultRelay`, plural `vaultagents`→`vaultrelays`) in **all three** chart locations: `kubevault-certified-crds`, `kubevault-crds`, `kubevault-operator`; plus the combined `crds/kubevault-crds.yaml`.
- `kubevault.com_vaultservers.yaml` schema: `agentTemplate`→`relayTemplate`, `agentPlacementRef`→`relayPlacementRef`, `agentPlacement`→`relayPlacement`, `RemoteAgent`→`RemoteRelay`, condition names → `Relay*`.
- Operator RBAC (`cluster-role.yaml`) + prose updated.

`helm lint` passes for the operator and certified-crds charts. Zero `VaultAgent`/`vaultagent`/`spoke-agent` references remain (non-vendor).

Kept: OCM 'work agent'/klusterlet, `monitoring-agent-api`, user-agent.