### PR TITLE
Rename VaultAgent to VaultRelay in charts/CRDs

### DIFF
--- a/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-certified-crds/crds/kubevault.com_vaultrelays.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: VaultRelayList
     plural: vaultrelays
     shortNames:
-    - va
+    - vr
     singular: vaultrelay
   scope: Namespaced
   versions:

--- a/charts/kubevault-certified-crds/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-certified-crds/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultrelays.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: VaultRelayList
     plural: vaultrelays
     shortNames:
-    - va
+    - vr
     singular: vaultrelay
   scope: Namespaced
   versions:

--- a/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-crds/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -11,12 +11,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultrelays.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: VaultRelayList
     plural: vaultrelays
     shortNames:
-    - va
+    - vr
     singular: vaultrelay
   scope: Namespaced
   versions:

--- a/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
+++ b/charts/kubevault-operator/crds/kubevault.com_vaultservers.yaml
@@ -4711,7 +4711,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -4860,14 +4860,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -12557,7 +12557,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/charts/kubevault-operator/templates/cluster-role.yaml
+++ b/charts/kubevault-operator/templates/cluster-role.yaml
@@ -141,7 +141,7 @@ rules:
   - clusterclaims
   verbs: ["get"]
   resourceNames: ["features.ace.info"]
-# OCM hub-driven spoke agent placement (VaultServer spec.agentPlacementRef):
+# OCM hub-driven spoke relay placement (VaultServer spec.relayPlacementRef):
 # resolve Placements through PlacementDecisions and maintain one ManifestWork
 # per selected managed cluster. The operator also creates ServiceAccounts and
 # Secrets in the managed cluster namespaces on the hub (covered by the core

--- a/crds/kubevault-crds.yaml
+++ b/crds/kubevault-crds.yaml
@@ -1973,7 +1973,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: kubevault
-  name: vaultagents.kubevault.com
+  name: vaultrelays.kubevault.com
 spec:
   group: kubevault.com
   names:
@@ -1981,12 +1981,12 @@ spec:
     - vault
     - appscode
     - all
-    kind: VaultAgent
-    listKind: VaultAgentList
-    plural: vaultagents
+    kind: VaultRelay
+    listKind: VaultRelayList
+    plural: vaultrelays
     shortNames:
     - va
-    singular: vaultagent
+    singular: vaultrelay
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -9602,7 +9602,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32
@@ -9751,14 +9751,14 @@ spec:
             type: object
           spec:
             properties:
-              agentPlacementRef:
+              relayPlacementRef:
                 properties:
                   name:
                     default: ""
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              agentTemplate:
+              relayTemplate:
                 properties:
                   bootstrapTokenTTL:
                     type: string
@@ -17448,7 +17448,7 @@ spec:
             type: object
           status:
             properties:
-              agentPlacement:
+              relayPlacement:
                 properties:
                   applied:
                     format: int32

--- a/crds/kubevault-crds.yaml
+++ b/crds/kubevault-crds.yaml
@@ -1985,7 +1985,7 @@ spec:
     listKind: VaultRelayList
     plural: vaultrelays
     shortNames:
-    - va
+    - vr
     singular: vaultrelay
   scope: Namespaced
   versions:


### PR DESCRIPTION
Renames `VaultAgent` to `VaultRelay` across the Helm charts and CRDs (agent → relay).

Includes changing the CRD short name from `va` to `vr` in the synced `vaultrelays` CRDs (`charts/*/crds/kubevault.com_vaultrelays.yaml` and `crds/kubevault-crds.yaml`).

Synced from kubevault/apimachinery#159.