### PR TITLE
Build kubevault-certified dependencies in update-chart-dependencies.sh

### DIFF
--- a/hack/scripts/update-chart-dependencies.sh
+++ b/hack/scripts/update-chart-dependencies.sh
@@ -17,4 +17,5 @@
 set -e
 
 helm dependency update charts/kubevault
+helm dependency update charts/kubevault-certified
 helm dependency update charts/kubevault-opscenter


### PR DESCRIPTION
Follow-up to #456.

#456 gitignored the vendored subchart archives under `charts/kubevault-certified/charts` (matching `kubedb/installer`) so `verify-catalog` stops failing on non-reproducible `helm`-packaged `.tgz`. But `hack/scripts/update-chart-dependencies.sh` only built the umbrella and opscenter charts' dependencies, so the certified chart's `charts/` directory is now empty at publish/install time.

The OCI publish flow (`helm package charts/kubevault-certified`) fails in that state with:

```
Error: found in Chart.yaml, but missing in charts/ directory: kubevault-crds, kubevault-catalog, kubevault-operator, kubevault-webhook-server, ace-user-roles
```

Fix: also build the certified chart's dependencies, matching `kubedb/installer`:

```
helm dependency update charts/kubevault
helm dependency update charts/kubevault-certified
helm dependency update charts/kubevault-opscenter
```