### PR TITLE
Grant the operator pods patch for role labeling

### DIFF
--- a/charts/kubevault-operator/templates/cluster-role.yaml
+++ b/charts/kubevault-operator/templates/cluster-role.yaml
@@ -97,7 +97,11 @@ rules:
   - pods
   - pods/exec
   - pods/eviction
-  verbs: ["get", "create", "list", "watch", "delete"]
+  # patch: the operator grants `pods: get, patch` to each vault
+  # ServiceAccount (the unsealer sidecar labels its own pod with
+  # kubevault.com/role); RBAC escalation prevention requires the
+  # grantor to hold the permission itself.
+  verbs: ["get", "create", "list", "watch", "patch", "delete"]
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
The operator creates a namespace Role granting each vault ServiceAccount pods get/patch so the unsealer sidecar can label its own pod with kubevault.com/role (the client Service selects role=primary for raft backends). RBAC escalation prevention requires the operator to hold pods patch itself to create that Role, so this adds pods patch to the operator ClusterRole.

Accompanies the operator PR (https://github.com/kubevault/operator/pull/219): the operator can only grant pods patch to the vault ServiceAccount if it holds that verb itself, so this RBAC change must ship with it.