### PR TITLE
Add make refresh target and require it before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ All Make targets run inside `ghcr.io/appscode/golang-dev` — Docker must be run
 - `make gen-values-schema` — regenerate `values.openapiv3_schema.yaml` from the Go types.
 - `make gen-chart-doc` — regenerate per-chart `README.md`.
 - `make update-charts` — refresh chart-level metadata.
+- `make refresh` — `gen update-catalog fmt`. **ALWAYS run this before opening a PR** so generated files are current.
 - `make fmt`, `make lint`, `make unit-tests` / `make test` — standard.
 - `make ct` — chart-testing lint+test.
 - `make verify` — `verify-modules`; `go mod tidy && go mod vendor` must leave the tree clean.

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,9 @@ manifests: gen-crds gen-values-schema gen-chart-doc
 .PHONY: gen
 gen: clientset manifests
 
+.PHONY: refresh
+refresh: gen update-catalog fmt
+
 BIN_DIR ?= $(CURDIR)/bin/$(OS)_$(ARCH)
 
 .PHONY: install-image-packer


### PR DESCRIPTION
Adds a `refresh` Makefile target that chains `gen`, `update-catalog`, and `fmt`, and documents in AGENTS.md that it should always be run before opening a PR so generated files stay current.

```makefile
.PHONY: refresh
refresh: gen update-catalog fmt
```